### PR TITLE
Xygeni-Bumper bump electron from 7.2.4 to 15.5.5

### DIFF
--- a/src/bad_components/bad_1/package.json
+++ b/src/bad_components/bad_1/package.json
@@ -6,7 +6,7 @@
     "main": "server.js",
     "dependencies": {
         "lodash": "4.17.11",
-        "electron": "7.2.4",
+        "electron": "15.5.5",
         "crossenv": "1.0.0"
     },
     "repository": "https://github.com/OWASP/NodejsGoat",


### PR DESCRIPTION
# 🛡️ Xygeni Bumper 

Bumps electron: 7.2.4 to 15.5.5

## 🔍 Vulnerability Details

- **Component:** electron
- **Fixed Version:** 15.5.5

## 📝 Description

Electron is a framework for writing cross-platform desktop applications using JavaScript (JS), HTML, and CSS. A vulnerability in versions prior to 18.0.0-beta.6, 17.2.0, 16.2.6, and 15.5.5 allows a renderer with JS execution to obtain access to a new renderer process with `nodeIntegrationInSubFrames` enabled which in turn allows effective access to `ipcRenderer`. The `nodeIntegrationInSubFrames` option does not implicitly grant Node.js access. Rather, it depends on the existing sandbox setting. If an application is sandboxed, then `nodeIntegrationInSubFrames` just gives access to the sandboxed renderer APIs, which include `ipcRenderer`. If the application then additionally exposes IPC messages without IPC `senderFrame` validation that perform privileged actions or return confidential data this access to `ipcRenderer` can in turn compromise your application / user even with the sandbox enabled. Electron versions 18.0.0-beta.6, 17.2.0, 16.2.6, and 15.5.5 contain a fix for this issue. As a workaround, ensure that all IPC message handlers appropriately validate `senderFrame`.

## 🔗 References

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2022-29247.

