### PR TITLE
Xygeni-Bumper bump lodash from 4.17.11 to 4.17.20

### DIFF
--- a/src/bad_components/bad_1/package.json
+++ b/src/bad_components/bad_1/package.json
@@ -5,7 +5,7 @@
     "description": "npm-no-pinned",
     "main": "server.js",
     "dependencies": {
-        "lodash": "4.17.11",
+        "lodash": "4.17.20",
         "electron": "7.2.4",
         "crossenv": "1.0.0"
     },


### PR DESCRIPTION
# 🛡️ Xygeni Bumper 

Bumps lodash: 4.17.11 to 4.17.20

## 🔍 Vulnerability Details

- **Component:** lodash
- **Fixed Version:** 4.17.20

## 📝 Description

Prototype pollution attack when using _.zipObjectDeep in lodash before 4.17.20.

## 🔗 References

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2020-8203.

