### PR TITLE
Xygeni-Bumper bump lodash from 4.17.11 to 4.17.12

### DIFF
--- a/src/bad_components/bad_1/package.json
+++ b/src/bad_components/bad_1/package.json
@@ -5,7 +5,7 @@
     "description": "npm-no-pinned",
     "main": "server.js",
     "dependencies": {
-        "lodash": "4.17.11",
+        "lodash": "4.17.12",
         "electron": "7.2.4",
         "crossenv": "1.0.0"
     },


### PR DESCRIPTION
# 🛡️ Xygeni Bumper 

Bumps lodash: 4.17.11 to 4.17.12

## 🔍 Vulnerability Details

- **Component:** lodash
- **Fixed Version:** 4.17.12

## 📝 Description

Versions of lodash lower than 4.17.12 are vulnerable to Prototype Pollution. The function defaultsDeep could be tricked into adding or modifying properties of Object.prototype using a constructor payload.

## 🔗 References

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2019-10744.

